### PR TITLE
bugfix issue #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This changelog is based on a previous changelog that had to depricated and removed due to the transition to GitHub.
 
+## [0.0.4]
+### Changed
+* Token aquisition is done only once per Timewatch session
+
+### Bugfix [issue #5](https://github.com/bouncingjack/twu/)
+* Bug - when multiple days are entered. The session does not transition well between edit windows. Therefore the next day recieves the wrong window to search for user token.
+    * Fix - check for token before searching for it. If it exists, do nothing.
+
 ## [0.0.3]
 ### Added
 * Timewatch fill based on timeline or spoofing

--- a/twkml.py
+++ b/twkml.py
@@ -66,11 +66,11 @@ class KMLFile:
 
     def _download_file(self):
         logger.debug('Start download of kml file')
-        chrome_path = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"
-        webbrowser.register('chrome', None, webbrowser.BackgroundBrowser(chrome_path), 1)
         if platform.system() == 'Linux':
             webbrowser.get('google-chrome').open_new(self._generate_timeline_url())
         elif platform.system() == 'Windows':
+            chrome_path = "C:\\Program Files (x86)\\Google\\Chrome\\Application\\chrome.exe"
+            webbrowser.register('chrome', None, webbrowser.BackgroundBrowser(chrome_path), 1)
             webbrowser.get('chrome').open_new(self._generate_timeline_url())
         else:
             raise ValueError(f'{platform.system()} is not a supported os')

--- a/twweb.py
+++ b/twweb.py
@@ -84,18 +84,7 @@ class TimeWatch:
         :param datetime edit_date: date that needs to be edited
         :return str: url for direct edit form for edit_date
         """
-        elems = [e.get_attribute('href') for e in self._driver.find_elements_by_xpath("//a[@href]")]
-        elems = [e for e in elems if 'editwh.php' in e]
-        try:
-            match = re.search(pattern=('(?<=ee\=)\d*(?=\&e)'), string=elems[0])
-        except IndexError as e:
-            raise IndexError('source of html page has no href with token')
-        
-        if match:
-            self._user_cred['token'] = match[0]
-        else:
-            raise ValueError('did not extract token from %s', elems[0])
-
+        self._set_token()
         base_url = 'http://checkin.timewatch.co.il/punch/editwh2.php?ie='
         comp_num = str(self._user_cred['company']) + '&e=' + str(self._user_cred['token']) + '&d='
         start_date = str(edit_date.year) + '-' + str(edit_date.month) + '-' + str(edit_date.day) + '&jd='
@@ -103,5 +92,27 @@ class TimeWatch:
                     + str(self._user_cred['token'])
         return base_url + comp_num + start_date + end_date
 
+    def _set_token(self):
+        """
+        checks if user token has already been processed. if so, does nothing. 
+        if not, this function recovers user token from source of web page and puts it in this class user credential paramters.
+        :return: Nothing
 
+        """
+        if 'token' in self._user_cred.keys():
+            logger.debug('user token already set')
+        else:
+            logger.debug('setting user token')
+
+            elems = [e.get_attribute('href') for e in self._driver.find_elements_by_xpath("//a[@href]")]
+            elems = [e for e in elems if 'editwh.php' in e]
+            try:
+                match = re.search(pattern=('(?<=ee\=)\d*(?=\&e)'), string=elems[0])
+            except IndexError as e:
+                raise IndexError('source of html page has no href with token')
+            
+            if match:
+                self._user_cred['token'] = match[0]
+            else:
+                raise ValueError('did not extract token from %s', elems[0])
 


### PR DESCRIPTION
Bug root cause:
when multiple edit dates supplied, application tries to open multiple edit window.
however, the transition does not work well and the resulting web page is not correct. 
Therefore, searching in it for the user token results in an exception.

Fix:
Check for existence of user token.
If user token already exists - no need to do anything.

encapsulate this in a new method.

